### PR TITLE
add category index

### DIFF
--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '../../layouts/Layout.astro
+import Header from '../../components/Header.astro
+import Footer from '../../components/Footer.astro
+import { getCollection} from 'astro:content';
+const allBlogPosts = await getCollection("blog");
+import Card from '../../components/Card.astro
+---
+<Layout>
+  <Header />
+  <main>
+    <h1>Blog</h1>
+    <section>
+	    <ul>
+      {allBlogPosts.map((post) => (
+       			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/blog" tags={post.data.tag} /></li>
+      ))}
+	    </ul>
+    </section>
+  </main>
+  <Footer />

--- a/src/pages/blog/tags/[slug].astro
+++ b/src/pages/blog/tags/[slug].astro
@@ -21,7 +21,7 @@ const posts = await getCollection("blog", ({data}) => data.tag.includes(tag));
 		<h1>Posts tagged with {tag}</h1>
 		<ul>
 			{posts.map((post) => (
-			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/blog" tags={post.data.tag} /></li>
+			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/blog" tags={post.data.tag} </li>
 			))}
 		</ul>
 	</main>

--- a/src/pages/blog/tags/[slug].astro
+++ b/src/pages/blog/tags/[slug].astro
@@ -1,0 +1,28 @@
+---
+import { getCollection} from 'astro:content';
+import Layout from '../../../layouts/Layout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import Card from '../../../components/Card.astro';
+export async function getStaticPaths() {
+	const allBlogPosts = await getCollection("blog");
+	const uniqueTags = [...new Set(allBlogPosts.map((post) => post.data.tag).flat())];
+	return uniqueTags.map((tag) => ({
+		params: { slug: tag },
+		props: { tag },
+	}));
+}
+const {tag} = Astro.props;
+const posts = await getCollection("blog", ({data}) => data.tag.includes(tag));
+---
+<Layout>
+	<Header />
+	<main>
+		<h1>Posts tagged with {tag}</h1>
+		<ul>
+			{posts.map((post) => (
+			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/blog" tags={post.data.tag} /></li>
+			))}
+		</ul>
+	</main>
+	<Footer />

--- a/src/pages/philosophy/index.astro
+++ b/src/pages/philosophy/index.astro
@@ -1,0 +1,21 @@
+---
+import Layout from '../../layouts/Layout.astro
+import Header from '../../components/Header.astro
+import Footer from '../../components/Footer.astro
+import { getCollection} from 'astro:content';
+const allBlogPosts = await getCollection("philosophy");
+import Card from '../../components/Card.astro
+---
+<Layout>
+  <Header />
+  <main>
+    <h1>Blog</h1>
+    <section>
+	    <ul>
+      {allBlogPosts.map((post) => (
+       			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/philosophy" tags={post.data.tag} /></li>
+      ))}
+	    </ul>
+    </section>
+  </main>
+  <Footer />

--- a/src/pages/philosophy/tags/[slug].astro
+++ b/src/pages/philosophy/tags/[slug].astro
@@ -1,0 +1,28 @@
+---
+import { getCollection} from 'astro:content';
+import Layout from '../../../layouts/Layout.astro';
+import Header from '../../../components/Header.astro';
+import Footer from '../../../components/Footer.astro';
+import Card from '../../../components/Card.astro';
+export async function getStaticPaths() {
+	const allBlogPosts = await getCollection("philosophy");
+	const uniqueTags = [...new Set(allBlogPosts.map((post) => post.data.tag).flat())];
+	return uniqueTags.map((tag) => ({
+		params: { slug: tag },
+		props: { tag },
+	}));
+}
+const {tag} = Astro.props;
+const posts = await getCollection("philosophy", ({data}) => data.tag.includes(tag));
+---
+<Layout>
+	<Header />
+	<main>
+		<h1 class="text-2sl font-bold">Posts tagged with {tag}</h1>
+		<ul class="ml-4 mr-auto p-4">
+			{posts.map((post) => (
+			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/philosophy" tags={post.data.tag} /></li>
+			))}
+		</ul>
+	</main>
+	<Footer />

--- a/src/pages/philosophy/tags/[slug].astro
+++ b/src/pages/philosophy/tags/[slug].astro
@@ -21,7 +21,7 @@ const posts = await getCollection("philosophy", ({data}) => data.tag.includes(ta
 		<h1 class="text-2sl font-bold">Posts tagged with {tag}</h1>
 		<ul class="ml-4 mr-auto p-4">
 			{posts.map((post) => (
-			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/philosophy" tags={post.data.tag} /></li>
+			<li><Card title={post.data.title} slug={post.id} date={post.data.updatedAt ?? post.data.publishedAt} base="/philosophy" tags={post.data.tag}</li>
 			))}
 		</ul>
 	</main>


### PR DESCRIPTION
- **✨ Add tag pages for blog and philosophy sections.  This allows users to easily browse posts by tag.  The pages dynamically generate based on available tags and display relevant posts.**
- **✨ Add blog and philosophy pages: Created new Astro pages to display blog posts and philosophy articles using a common Card component.  The pages fetch and display content from the respective collections.**
