### PR TITLE
Refactor: Centralize DatetoString function to utils

### DIFF
--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon } from "astro-icon/components";
+import { DatetoString } from "../../utils/dateUtils.ts";
 
 interface Props {
   title: string;
@@ -11,10 +12,6 @@ interface Props {
 
 const { title, date, slug, tags, base } = Astro.props as Props;
 const tagList = tags.slice(0, 3);
-const DatetoString = (stdate: string) => {
-    const date = new Date(stdate);
-    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
-};
 const DateString = DatetoString(date);
 ---
 <div class="card">

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -3,6 +3,7 @@ import { getCollection, render } from "astro:content";
 import Header from "../../components/Header.astro";
 import Image from "../../components/Image.astro";
 import Layout from "../../layouts/Layout.astro";
+import { DatetoString } from "../../../utils/dateUtils.ts";
 export async function getStaticPaths() {
 	const allPosts = await getCollection("posts");
 	return allPosts.map((post) => ({
@@ -31,10 +32,6 @@ const jsonLd = {
 const structuredData = `<script type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</script>`;
 const meta = `<title>${post.data.title}</title> ${structuredData}`;
 const { Content } = await render(post);
-const DatetoString = (stdate) => {
-	const date = new Date(stdate);
-	return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
-};
 import tocbot from "tocbot";
 ---
 <Layout meta={meta}>

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,4 @@
+export const DatetoString = (stdate: string): string => {
+  const date = new Date(stdate);
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+};


### PR DESCRIPTION
I moved the DatetoString function from Card.astro and [slug].astro to a common utility file at src/utils/dateUtils.ts.

This change eliminates code duplication, adhering to the DRY principle, and improves overall code maintainability. Both components now import the function from the central utility module.